### PR TITLE
add option to pass custom serializers

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var uuid = require('uuid');
 module.exports = function logRequest(options) {
   var logger = options.logger;
   var headerName = options.headerName || 'x-request-id';
+  var serializers = options.serializers;
 
   return function (req, res, next) {
     var id = req.headers[headerName] || uuid.v4();
@@ -12,7 +13,7 @@ module.exports = function logRequest(options) {
     req.log = logger.child({
       type: 'request',
       id: id,
-      serializers: logger.constructor.stdSerializers
+      serializers: serializers || logger.constructor.stdSerializers
     });
 
     if (req.body) {


### PR DESCRIPTION
custom serializer would be useful in allowing customization of logging output, specifically we want to scrub certain header fields from logs like cookies and authentication headers